### PR TITLE
Updates dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@antora/lunr-extension": "^1.0.0-alpha.8"
       },
       "devDependencies": {
-        "@hacbs-contract/ec-policies-antora-extension": "*",
-        "@hacbs-contract/reference-antora-extension": "*",
+        "@hacbs-contract/ec-policies-antora-extension": "latest",
+        "@hacbs-contract/reference-antora-extension": "latest",
         "antora": "^3.1.2"
       },
       "engines": {
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@hacbs-contract/ec-policies-antora-extension": {
-      "version": "0.0.3-78dd4c1.0",
-      "resolved": "https://registry.npmjs.org/@hacbs-contract/ec-policies-antora-extension/-/ec-policies-antora-extension-0.0.3-78dd4c1.0.tgz",
-      "integrity": "sha512-+d/MlbigFetkFUW5TVk9NUMApVi9780BTWuUnIcdqoaBR/o/DmOlSRBewmUjCasUdCjPUpNy87Nv1wO/9R7glw==",
+      "version": "0.0.3-7e9be20.0",
+      "resolved": "https://registry.npmjs.org/@hacbs-contract/ec-policies-antora-extension/-/ec-policies-antora-extension-0.0.3-7e9be20.0.tgz",
+      "integrity": "sha512-2acFWIdJI8XXfMO/S2eijZVITa/0301Q8rLF34N3/Z2Q8YiZxb/d+IKYyC+RYYaeLW0dNjbGK0jfH6TFsebCbQ==",
       "dev": true,
       "dependencies": {
         "@zregvart/opa-inspect": "latest"
@@ -351,9 +351,9 @@
       "dev": true
     },
     "node_modules/@zregvart/opa-inspect": {
-      "version": "0.44.0-dc1fa34",
-      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.44.0-dc1fa34.tgz",
-      "integrity": "sha512-9aWS4nbMqBPqii86FOY2p7CjlfOi1+3vuovNPFhnzPTmTNoMZ0NyocvhHtG6PImhIqZ3U0jYxsduP8EqWyQcCg==",
+      "version": "0.46.1-653ce00",
+      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.46.1-653ce00.tgz",
+      "integrity": "sha512-oRzreIxGO7gtK5KYL5cWDYCriwWjX0+dZ6GLCO+q2MdiscRZao/kcYsfuOmw6qAdXPg70XUer/xuUrPvddVE8g==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/async-lock": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.3.2.tgz",
-      "integrity": "sha512-phnXdS3RP7PPcmP6NWWzWMU0sLTeyvtZCxBPpZdkYE3seGLKSQZs9FrmVO/qwypq98FUtWWUEYxziLkdGk5nnA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -1553,9 +1553,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimisted": {
       "version": "2.0.1",
@@ -2227,9 +2230,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -2729,9 +2732,9 @@
       }
     },
     "@hacbs-contract/ec-policies-antora-extension": {
-      "version": "0.0.3-78dd4c1.0",
-      "resolved": "https://registry.npmjs.org/@hacbs-contract/ec-policies-antora-extension/-/ec-policies-antora-extension-0.0.3-78dd4c1.0.tgz",
-      "integrity": "sha512-+d/MlbigFetkFUW5TVk9NUMApVi9780BTWuUnIcdqoaBR/o/DmOlSRBewmUjCasUdCjPUpNy87Nv1wO/9R7glw==",
+      "version": "0.0.3-7e9be20.0",
+      "resolved": "https://registry.npmjs.org/@hacbs-contract/ec-policies-antora-extension/-/ec-policies-antora-extension-0.0.3-7e9be20.0.tgz",
+      "integrity": "sha512-2acFWIdJI8XXfMO/S2eijZVITa/0301Q8rLF34N3/Z2Q8YiZxb/d+IKYyC+RYYaeLW0dNjbGK0jfH6TFsebCbQ==",
       "dev": true,
       "requires": {
         "@zregvart/opa-inspect": "latest"
@@ -2750,9 +2753,9 @@
       "dev": true
     },
     "@zregvart/opa-inspect": {
-      "version": "0.44.0-dc1fa34",
-      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.44.0-dc1fa34.tgz",
-      "integrity": "sha512-9aWS4nbMqBPqii86FOY2p7CjlfOi1+3vuovNPFhnzPTmTNoMZ0NyocvhHtG6PImhIqZ3U0jYxsduP8EqWyQcCg==",
+      "version": "0.46.1-653ce00",
+      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.46.1-653ce00.tgz",
+      "integrity": "sha512-oRzreIxGO7gtK5KYL5cWDYCriwWjX0+dZ6GLCO+q2MdiscRZao/kcYsfuOmw6qAdXPg70XUer/xuUrPvddVE8g==",
       "dev": true
     },
     "abort-controller": {
@@ -2799,9 +2802,9 @@
       }
     },
     "async-lock": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.3.2.tgz",
-      "integrity": "sha512-phnXdS3RP7PPcmP6NWWzWMU0sLTeyvtZCxBPpZdkYE3seGLKSQZs9FrmVO/qwypq98FUtWWUEYxziLkdGk5nnA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
     },
     "atomic-sleep": {
       "version": "1.0.0",
@@ -3665,9 +3668,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "minimisted": {
       "version": "2.0.1",
@@ -4207,9 +4210,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uglify-js": {
       "version": "3.17.4",


### PR DESCRIPTION
This fixes the build because the underlying OPA version was updated to 0.46 which supports the new keywords/syntax used in the Rego rules.