### PR TITLE
Remove default run working-directory

### DIFF
--- a/.github/workflows/publish_antora.yaml
+++ b/.github/workflows/publish_antora.yaml
@@ -29,9 +29,6 @@ name: Publish Antora docs
 jobs:
   antora:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 'antora'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Remove default working-directory from publish_antora.yaml workflow