### PR TITLE
ADD generation of antora header nav from Hugo TOML

### DIFF
--- a/antora/hugo.toml
+++ b/antora/hugo.toml
@@ -1,0 +1,1 @@
+../website/hugo.toml

--- a/antora/package-lock.json
+++ b/antora/package-lock.json
@@ -14,9 +14,10 @@
       },
       "devDependencies": {
         "@enterprise-contract/ec-policies-antora-extension": "latest",
-        "@enterprise-contract/reference-antora-extension": "*",
-        "@enterprise-contract/tekton-task-antora-extension": "*",
-        "antora": "^3.1.3"
+        "@enterprise-contract/reference-antora-extension": "latest",
+        "@enterprise-contract/tekton-task-antora-extension": "latest",
+        "antora": "^3.1.3",
+        "toml": "^3.0.0"
       },
       "engines": {
         "node": "18"
@@ -2241,6 +2242,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "dev": true
     },
     "node_modules/tslib": {
       "version": "2.5.0",

--- a/antora/package.json
+++ b/antora/package.json
@@ -11,7 +11,9 @@
     "@enterprise-contract/ec-policies-antora-extension": "latest",
     "@enterprise-contract/reference-antora-extension": "latest",
     "@enterprise-contract/tekton-task-antora-extension": "latest",
-    "antora": "^3.1.3"
+    "antora": "^3.1.3",
+    "toml": "^3.0.0"
+
   },
   "overrides": {
     "glob-parent": "6.0.2"

--- a/antora/supplemental-ui/helpers/parseHugoMenu.js
+++ b/antora/supplemental-ui/helpers/parseHugoMenu.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const toml = require("toml");
+
+module.exports = () => {
+  const filePath = "./hugo.toml";
+  const fileContent = fs.readFileSync(filePath, "utf8");
+  const config = toml.parse(fileContent);
+  const menu = config.menu.main || [];
+  const processed = new Set();
+
+  const createMenu = (item) => {
+    if (processed.has(item)) {
+      return {};
+    }
+    processed.add(item);
+    const children = menu
+      .filter((child) => child.parent === item.name)
+      .map(createMenu);
+    const menuItem = {
+      name: item.name,
+      url: item.url,
+      pageRef: item.pageRef,
+      weight: item.weight || 0,
+      parent: item.parent,
+      graphic: item.graphic,
+    };
+    if (children.length) {
+      menuItem["children"] = children;
+    }
+    return menuItem;
+  };
+
+  const menuData = menu
+    .filter((item) => typeof item.parent === "undefined")
+    .map((item) => createMenu(item));
+  const sortedMenuData = menuData.sort((a, b) => a.weight - b.weight);
+  return sortedMenuData;
+};

--- a/antora/supplemental-ui/partials/github-icon-svg.hbs
+++ b/antora/supplemental-ui/partials/github-icon-svg.hbs
@@ -1,1 +1,0 @@
-../../../common/partials/github-icon-svg.html

--- a/antora/supplemental-ui/partials/header-content.hbs
+++ b/antora/supplemental-ui/partials/header-content.hbs
@@ -21,55 +21,7 @@
           </div>
         </div>
         {{/if}}
-
-        {{! See also website/hugo.toml which should be kept in sync with the links here
-          TODO: DRY it up and generate the menus from a single source. }}
-
-        <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/../">Home</a>
-
-        <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/../posts/">Blog</a>
-
-        <div class="navbar-item has-dropdown is-hoverable">
-
-          <span class="navbar-link">Documentation</span>
-          <div class="navbar-dropdown is-right">
-            {{! Todo: Maybe we can use #each site.components here }}
-
-            <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/">Overview</a>
-
-            {{! Let's link to a deeper page for these instead of the default index. The left menu should provide easy access to the other sections. }}
-            <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/ec-cli/main/ec_validate_image.html">CLI Reference</a>
-            <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/ec-cli/main/verify-enterprise-contract.html">Tekton Tasks</a>
-            <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/ecc/main/">Configuration</a>
-            <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/ec-policies/release_policy.html">Policies</a>
-
-            {{! I want to rename the cookbook soon, perhaps to User Guide, so let's try using that title }}
-            <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/user-guide/main/">User Guide</a>
-
-            {{! Coming soon... }}
-            {{!-- <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}/user-guide/main/SLSA/">RHTAP, EC &amp; SLSA</a> --}}
-
-          </div>
-        </div>
-
-        {{!--
-          This is a little undercooked. Let's comment it out for now and come back to it later.
-
-        <div class="navbar-item has-dropdown is-hoverable">
-          <span class="navbar-link">More</span>
-          <div class="navbar-dropdown">
-            <a class="navbar-item" target="_blank" href="https://github.com/enterprise-contract/">Source Code</a>
-            <a class="navbar-item" target="_blank" href="https://issues.redhat.com/issues/?jql=project%20%3D%20HACBS%20and%20labels%20%3D%20Contract">Issue Tracker</a>
-            {{! This is RH internal, so maybe it's not a good idea to link it }}
-            <a class="navbar-item" target="_blank" href="https://redhat-internal.slack.com/archives/C031J4KBFME">Slack Channel</a>
-            {{! More later maybe }}
-          </div>
-        </div>
-
-        --}}
-
-        <a class="navbar-item" href="https://github.com/enterprise-contract" title="Source Code">{{> github-icon-svg }}</a>
-
+        {{> hugo_nav}}
       </div>
     </div>
   </nav>

--- a/antora/supplemental-ui/partials/hugo_nav.hbs
+++ b/antora/supplemental-ui/partials/hugo_nav.hbs
@@ -1,0 +1,41 @@
+{{#each (parseHugoMenu)}}
+	{{#unless parent~}}
+		{{#if pageRef~}}
+			{{#if graphic~}}
+				<a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}{{pageRef~}}">{{graphic}}</a>
+			{{else~}}
+				<a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}{{pageRef~}}">{{name~}}</a>
+			{{/if~}}
+		{{else if url~}}
+			{{#if graphic~}}
+				<a class="navbar-item" href="{{url~}}" title="{{name}}">{{{graphic}}}</a>
+			{{else~}}
+				<a class="navbar-item" href="{{url~}}">{{name~}}</a>
+			{{/if~}}
+		{{else~}}
+			{{#if children~}}
+				<div class="navbar-item has-dropdown is-hoverable">
+			{{/if~}}
+			{{#if graphic~}}
+				<span class="navbar-link" title="{{name}}">{{graphic}}</span>
+			{{else~}}
+				<span class="navbar-link">{{name~}}</span>
+			{{/if~}}
+		{{/if~}}
+			{{#if children~}}
+		<div class="navbar-dropdown is-right">
+		{{#each children~}}
+			{{~#if pageRef~}}
+				<a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}{{pageRef~}}">{{name~}}</a>
+			{{~else if url~}}
+				<a class="navbar-item" href="{{url~}}">{{name~}}</a>
+			{{~else~}}
+				<span class="navbar-link">{{name~}}</span>
+			{{~/if~}}
+		{{/each~}}
+		</div>
+	</div>
+	{{/if~}}
+
+	{{/unless~}}
+{{/each}}

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -35,18 +35,8 @@ relativeURLs = true
     weight = 11
 
   [[menu.main]]
-    name = 'Source Code'
-    url = 'https://github.com/enterprise-contract'
-    weight = 50
-
-  #[[menu.main]]
-  #  name = 'About'
-  #  pageRef = '/about'
-  #  weight = 20
-
-  [[menu.main]]
     name = 'Documentation'
-    weight = 30
+    weight = 12
 
   [[menu.main]]
     parent = 'Documentation'
@@ -83,6 +73,15 @@ relativeURLs = true
     name = 'User Guide'
     url = '/docs/user-guide/main'
     weight = 70
+
+  [[menu.main]]
+    name = 'Source Code'
+    url = 'https://github.com/enterprise-contract'
+    weight = 13
+    graphic = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">
+  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+</svg>"""
+
 
 [module]
 [[module.imports]]


### PR DESCRIPTION
This commit satisfies HACBS-2110 and allows the navigation menu for the website to be defined in the `hugo.toml` file.
Note: Any links that are not part of the Hugo website, such as links to any portion of the Antora generated site, need to be under the key `url` instead of `pageRef` as `pageRef` is solely for Hugo generated pages.

SVG graphics can be used as menu content if the svg content is entered in the `graphic` key within the menu entry in the `hugo.toml` file.