### PR TITLE
Preview target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,14 +24,16 @@ name: Build
       - main
 
 jobs:
-  build-antora:
+  build-hugo:
     runs-on: ubuntu-latest
-
+    env:
+      HUGO_VERSION: 0.111.3
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - name: Setup NodeJS environment
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'antora/package.json'
           cache: 'npm'
@@ -40,41 +42,23 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
-          go-version-file: antora/go.mod
+          go-version-file: website/go.mod
           cache: true
-          cache-dependency-path: antora/go.sum
+          cache-dependency-path: website/go.sum
 
-      - name: Generate website
-        run: npm --prefix antora ci && npm --prefix antora run build
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          path: public
-          name: build-antora
-
-  build-hugo:
-    runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.111.3
-    steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Go environment
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: website/go.mod
-          cache: true
-          cache-dependency-path: website/go.sum
+
+      - name: Build documentation
+        run: npm --prefix antora ci && npm --prefix antora run build
+
       - name: Build with Hugo
         env:
-          # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
@@ -83,11 +67,12 @@ jobs:
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           path: public
-          name: build-hugo
+          name: website
 
   pull-request-data:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Unzip website artifact
         run: |
           mkdir public
-          unzip -q 'artifacts/data-[0-2].zip' -d public
+          unzip -q 'artifacts/data-[0-1].zip' -d public
           rm -rf artifacts
       - name: Setup pull request data
         id: data

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,15 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download hugo artifact
+      - name: Download website artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-hugo
-          path: '.'
-      - name: Download antora artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: build-antora
+          name: website
           path: '.'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Rendered documentation output
 public
 node_modules
+website/antora
 
 # Generated files by hugo
 /public/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build-hugo: hugo-theme ## Build hugo docs
 	@cd website && hugo --config hugo.toml
 	@echo file://$(PWD)/public/index.html
 
-build-all: build-hugo build-antora
+build-all: build-antora build-hugo
 
 ifndef THEME_NAME
 THEME_NAME=night-owl

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,7 @@
 help:
 	@grep '[[:space:]]##[[:space:]]' Makefile | sed 's/^\(.*\):.*##\(.*\)$$/#\2\nmake \1\n/'
 
-website/themes/antora-default-ui-hugo-theme:
-	@git submodule update --init
-
-hugo-theme: website/themes/antora-default-ui-hugo-theme
-
-hugo-server: hugo-theme ## Run hugo server for website hacking
+hugo-server: ## Run hugo server for website hacking
 	@cd website && hugo server --config hugo.toml
 
 antora-local-build: ## Build antora docs once using your locally checked out git repos
@@ -24,7 +19,7 @@ build-antora-fast: ## Build antora docs without re-fetching sources
 
 # Fixme: Not sure how to make the stylesheet and javascript urls work
 PWD=$(shell pwd)
-build-hugo: hugo-theme ## Build hugo docs
+build-hugo: ## Build hugo docs
 	@cd website && hugo --config hugo.toml
 	@echo file://$(PWD)/public/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 help:
 	@grep '[[:space:]]##[[:space:]]' Makefile | sed 's/^\(.*\):.*##\(.*\)$$/#\2\nmake \1\n/'
 
-hugo-server: ## Run hugo server for website hacking
+preview: preview-antora ## Run hugo server for website hacking
 	@cd website && hugo server --config hugo.toml
 
 antora-local-build: ## Build antora docs once using your locally checked out git repos
@@ -10,6 +10,9 @@ antora-local-build: ## Build antora docs once using your locally checked out git
 
 antora-local-live: ## Live build antora docs your locally checked out git repos
 	@cd antora && hack/local-live.sh
+
+preview-antora: ## Build antora docs
+	@cd antora && npm ci && URL=http://localhost:1313/docs npm run build
 
 build-antora: ## Build antora docs
 	@cd antora && npm ci && npm run build

--- a/antora/antora-playbook.yml
+++ b/antora/antora-playbook.yml
@@ -46,7 +46,7 @@ ui:
     snapshot: true
   supplemental_files: ./supplemental-ui
 output:
-  dir: ../public/docs
+  dir: ../website/antora/docs
 antora:
   extensions:
 # Order here determines the order of execution, this is important for the

--- a/antora/go.mod
+++ b/antora/go.mod
@@ -1,3 +1,0 @@
-module github.com/enterprise-contract/enterprise-contract.github.io
-
-go 1.19

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -5,6 +5,7 @@ theme = 'github.com/basil/antora-default-ui-hugo-theme'
 publishDir = '../public'
 copyright = "Red Hat, Inc. All rights reserved."
 relativeURLs = true
+staticDir = ["static", "antora"]
 
 [params]
   since = 2023


### PR DESCRIPTION
With this running `make preview` builds the documentation with Antora and runs the Hugo server to serve the website and Antora content.

This relies on [Add Antora built documentation as static resource](https://github.com/enterprise-contract/enterprise-contract.github.io/pull/66/commits/ee5f7e095386e2d7f29fed5d10f47e491174d6df)

This way when running `hugo serve` the Antora built documentation is available on `/docs` as well.
Since the output of the Antora built is nested within the `website/antora/docs` and then copied over by Hugo to `public/docs` the two build steps and artifacts would no longer work on GitHub Workflows, so this also unifies them to a single build step.
