### PR TITLE
Add download button to the front page

### DIFF
--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -145,6 +145,10 @@ body.article {
   padding-top: 0;
 }
 
+.wide article.doc article {
+  margin-top: 3rem;
+}
+
 footer.footer {
   /* Cosmetic tweak so the footer color continues to the bottom for short pages */
   padding-bottom: 15em;
@@ -205,7 +209,7 @@ footer.footer {
   .header .circle3 { top: -19vw; }
 }
 
-.button {
+h3.button {
     display: inline-block;
     background-color: var(--ec-navbar-purple);
     box-shadow: 1px 1px 4px 0px gray;
@@ -213,9 +217,15 @@ footer.footer {
     border: 0;
     padding: 0.5rem 1rem 0.3rem;
     cursor: pointer;
+    margin-top: 3rem;
+}
+
+.button:not(:first-child) {
+  margin-left: 0.5rem;
 }
 
 .button a {
+    display: inline-flex;
     text-decoration: none;
     color: white;
 }
@@ -224,10 +234,19 @@ footer.footer {
     color: white;
 }
 
-/* hack hack */
-#view-the-documentationdocsindexhtml {
-    margin-top: 2em;
-    margin-bottom: 3em;
+.button svg {
+  margin-right: 0.5rem;
+}
+
+.button svg path {
+  stroke: white;
+}
+
+a.all-downloads {
+  display: block;
+  position: absolute;
+  color: var(--color-gray-30);
+  padding-left: 1rem;
 }
 
 p.big {

--- a/website/assets/js/07-download.js
+++ b/website/assets/js/07-download.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const download = document.querySelector('#download a');
+    if (!download) {
+        return
+    }
+    try {
+        const response = await fetch('https://api.github.com/repos/enterprise-contract/ec-cli/releases/tags/snapshot');
+        const snapshot = await response.json();
+        const uap = new UAParser();
+        const os = uap.getOS().name.replace('macOS', 'darwin').toLowerCase();
+        const arch = uap.getCPU().architecture;
+        const file = `ec_${os}_${arch}`;
+        const asset = snapshot.assets.find(a => a.name === file);
+        if (asset) {
+            download.parentNode.insertAdjacentHTML('afterend', `<a class="all-downloads" href=${download.href}>(All downloads)</a>`)
+            download.href = asset.browser_download_url;
+            download.title = `${uap.getOS().name} / ${uap.getCPU().architecture}`;
+        }
+    } catch(e) {
+        // Unable to fetch the releases leave the download link as is
+        return;
+    }
+})

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -16,4 +16,4 @@ how container images are built and tested.
 
 ### [{{< icon "arrow-down-circle" >}} Download](https://github.com/enterprise-contract/ec-cli/releases/tag/snapshot){#download .button}
 
-### [{{< icon "book-open" >}} View the documentation](./docs/index.html){.button}
+### [{{< icon "book-open" >}} Documentation](./docs/index.html){.button}

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -14,4 +14,6 @@ how container images are built and tested.
 
 {{</rawhtml>}}
 
-### [View the documentation](./docs/index.html){.button}
+### [{{< icon "arrow-down-circle" >}} Download](https://github.com/enterprise-contract/ec-cli/releases/tag/snapshot){#download .button}
+
+### [{{< icon "book-open" >}} View the documentation](./docs/index.html){.button}

--- a/website/go.mod
+++ b/website/go.mod
@@ -4,5 +4,6 @@ go 1.19
 
 require (
 	github.com/basil/antora-default-ui-hugo-theme v0.0.0-20210103230659-17b9bc527014 // indirect
+	github.com/faisalman/ua-parser-js v0.7.1 // indirect
 	github.com/gohugoio/hugo-mod-heroicons v0.0.0-20230311221257-aa5a3a372386 // indirect
 )

--- a/website/go.sum
+++ b/website/go.sum
@@ -1,5 +1,7 @@
 github.com/basil/antora-default-ui-hugo-theme v0.0.0-20210103230659-17b9bc527014 h1:Rz9M6xM45T06+JyKpeRdPBQTqnCug4m7mfbi6Go91hw=
 github.com/basil/antora-default-ui-hugo-theme v0.0.0-20210103230659-17b9bc527014/go.mod h1:axVFIhw8O9beSTVrHRkgN/QU2RESkkNdAk6ICv1RK9s=
+github.com/faisalman/ua-parser-js v0.7.1 h1:kI9gwcJsW6mip2LLkKM/ROWL3wr6+0rkFU33ZKf0luc=
+github.com/faisalman/ua-parser-js v0.7.1/go.mod h1:OIN2lSqEtPIApeElk85FgIakGCniJ+LxdBfUZr3p8YY=
 github.com/gohugoio/hugo-mod-heroicons v0.0.0-20230311221257-aa5a3a372386 h1:4ssTg+cPu0aiV35lrF2APJ+6d3/s909LcAyC30d+Sd8=
 github.com/gohugoio/hugo-mod-heroicons v0.0.0-20230311221257-aa5a3a372386/go.mod h1:Dr4s5WED0qTYSmJtl8LXknqSaO4Jmw5UF6OqKMCWaxo=
 github.com/tailwindlabs/heroicons v2.0.16+incompatible/go.mod h1:2SHGOdw86jviBkoeQINcTfkzAAao9dciip4RsMS9xIg=

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -90,3 +90,9 @@ staticDir = ["static", "antora"]
 
 [[module.imports]]
 path = "github.com/gohugoio/hugo-mod-heroicons"
+
+[[module.imports]]
+path = "github.com/faisalman/ua-parser-js"
+[[module.imports.mounts]]
+source = "src"
+target = "assets/js/vendor"

--- a/website/layouts/partials/footer-scripts.html
+++ b/website/layouts/partials/footer-scripts.html
@@ -1,0 +1,15 @@
+<div id="copy-to-clipboard" style="display: none;" data-svg="{{ "/img/octicons-16.svg" | relURL }}"></div>
+{{ $site := resources.Match "js/*.js" | resources.Concat "js/site.js" | resources.Minify | resources.Fingerprint }}
+<script src="{{ $site.RelPermalink }}" {{ $site.Data.Integrity | printf "integrity=%q" | safeHTMLAttr }}></script>
+{{ $highlight := resources.Get "js/vendor/highlight.pack.js" | resources.Fingerprint }}
+<script src="{{ $highlight.RelPermalink }}" {{ $highlight.Data.Integrity | printf "integrity=%q" | safeHTMLAttr }}></script>
+<script>
+;[].slice.call(document.querySelectorAll('pre code.hljs')).forEach(function (node) {
+  hljs.highlightBlock(node)
+})
+</script>
+{{ $uaParser := resources.Get "js/vendor/ua-parser.min.js" | resources.Fingerprint }}
+<script src="{{ $uaParser.RelPermalink }}" {{ $uaParser.Data.Integrity | printf "integrity=%q" | safeHTMLAttr }}></script>
+{{ if not .Site.IsServer -}}
+  {{ template "_internal/google_analytics.html" . }}
+{{- end }}


### PR DESCRIPTION
By default the download button links to to the rolling release[1] on GitHub, with JavaScript enabled and given support for the OS/architecture the link is changed to the appropriate release asset and an "All downloads" link is added to point to the rolling releases page on GitHub.

Partial for the footer scripts is now generic and allows adding additional scripts to the `website/assets/js` directory.

Ref. https://issues.redhat.com/browse/HACBS-2214

[1] https://github.com/enterprise-contract/ec-cli/releases/tag/snapshot