### PR TITLE
Tweak max height for zoomed in image

### DIFF
--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -304,7 +304,7 @@ p.big {
   position: fixed;
   margin-top: 0;
   z-index: 1000;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0,0,0,0.75);
   outline: none;
 }
 
@@ -317,6 +317,10 @@ p.big {
   right: 0;
   align-items: center;
   justify-content: center;
+}
+
+.zoom.shown .imageblock img {
+   max-height: 92vh;
 }
 
 .zoom.shown .imageblock .title {


### PR DESCRIPTION
Without a max height, depending on their aspect ration, some images can be taller than the screen when zoomed in, which is not a good UX. Also you can't see the caption. Keeping some room for the caption is why I set it to 92vh instead of 100vh.

Also made the backdrop slightly darker.