### PR TITLE
Fix source toolbox

### DIFF
--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -669,3 +669,25 @@ g.parallax4 {
   }
 }
 /* end front page divider */
+
+/* source toolbox */
+.doc .listingblock > .content {
+  position: relative;
+}
+
+.wide .doc .listingblock > .content {
+  margin-top: 0;
+}
+
+.doc .source-toolbox {
+  top: 1rem;
+}
+
+.doc .source-toolbox img.copy-icon {
+  -webkit-filter: invert(50.2%);
+  filter: invert(50.2%);
+}
+
+.doc .source-toolbox .copy-toast {
+  width: 4rem;
+}

--- a/website/layouts/shortcodes/code.html
+++ b/website/layouts/shortcodes/code.html
@@ -10,8 +10,8 @@
   highlightjs work. I'm copying from the Antora output.
 
 */}}
-<pre class="highlightjs">
-<code class="hljs{{ with .Get 0 }} language-{{ . }}{{ end }}">
-{{- trim .Inner "\n" -}}
-</code>
-</pre>
+<div class="listingblock">
+  <div class="content">
+    <pre class="highlightjs highlight"><code class="hljs{{ with .Get 0 }} language-{{ . }}" data-lang="{{ . }}{{ end }}">{{- trim .Inner "\n" -}}</code></pre>
+  </div>
+</div>


### PR DESCRIPTION
Fixes the copy button positioning on Antora-rendered pages and introduces the source toolbox functionality to Hugo-rendered pages.

Ref. https://issues.redhat.com/browse/HACBS-2265