### PR TITLE
HACBS-2522 Embed community calendar

### DIFF
--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -739,6 +739,11 @@ ul.pagination
   margin: 0;
 }
 
+.contribute>p.ics-download {
+  text-align: right;
+  font-size: .5em;
+}
+
 @media screen and (max-width: 1023px) {
   .contribute img, .contribute img.icon{
     width: 100%;

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -57,6 +57,8 @@
             <img src="https://contrib.rocks/image?repo=enterprise-contract/ec-cli&columns=7&max=100">
             <p>Join us for our weekly community meeting, held every Wednesday at <a href="https://www.timeanddate.com/worldclock/converter.html?iso=20210518T140000&p1=1440&p2=4826&p3=234&p4=195" title="Find the meeting time in your local timezone">10am Eastern</a>.</p>
             <p>The meeting <a href="https://github.com/enterprise-contract/community/issues?q=is%3Aopen+is%3Aissue+label%3Acommunity-meeting+" title="View upcoming meeting agenda">agenda and joining details are available as a Github issue</a> shortly before the meeting. </p>
+            <iframe src="https://calendar.google.com/calendar/embed?src=enterprisecontractcommunity%40gmail.com&ctz=America%2FNew_York" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+            <p class="ics-download">Download calendar .ics file <a href="https://calendar.google.com/calendar/ical/enterprisecontractcommunity%40gmail.com/public/basic.ics">here</a></p>
         </div>
       </main>
     </div>


### PR DESCRIPTION
This commit embeds the community calendar created in HACBS-2521 on the front page of the website. It also adds a link for downloading the ics file for the calendar.