### PR TITLE
Update go version to match ec-cli version

### DIFF
--- a/website/go.mod
+++ b/website/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/enterprise-contract.github.io/website
 
-go 1.19
+go 1.21.2
 
 require (
 	github.com/basil/antora-default-ui-hugo-theme v0.0.0-20210103230659-17b9bc527014 // indirect


### PR DESCRIPTION
The ec-cli now uses go 1.21 which allows the line starting with `go` in the go.mod file to contains a version in the format major.minor.patch. Without this change CI fails because the version used is too old and does not understand the new syntax.