### PR TITLE
EC-32 Link to guide for newcomers from homepage

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,4 +4,4 @@ kind: home
 
 ### [{{< icon "arrow-down-circle" >}} Download](https://github.com/enterprise-contract/ec-cli/releases/tag/snapshot){#download .button}
 
-### [{{< icon "book-open" >}} Documentation](./docs/index.html){.button}
+### [{{< icon "book-open" >}} Getting Started](./docs/user-guide/main/hitchhikers-guide.html){.button}


### PR DESCRIPTION
This commit replaces the documentation link on the homepage for one pointing to the Hitchhiker's Guide documentation. The previous link to the documentation overview was duplicated by the "Overview" link in the "Documentation" menu previously and has been left in place.

resolves: EC-32