### PR TITLE
Replace link to Slack with invite link

### DIFF
--- a/website/layouts/_default/contribute.html
+++ b/website/layouts/_default/contribute.html
@@ -48,7 +48,7 @@
                         </div>
                     </div>
                     <div class="slack">
-                        <a href="https://enterprisecontract.slack.com/" title="Join the Enterprise-Contract Slack">
+                        <a href="https://join.slack.com/t/enterprisecontract/shared_invite/zt-26l68e6wj-apw7c55CsDtd6Q9TgtiGuw" title="Join the Enterprise-Contract Slack">
                             <div class="slack-details">
                                 <div class="icon">
                                     {{ partial "slack-icon-svg.html" . }}


### PR DESCRIPTION
Replaced the direct link to Slack with a non-expiring invite link to enable anyone to join.