### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,7 @@ jobs:
     needs: build
     steps:
       - name: Download website artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: website
           path: '.'


### PR DESCRIPTION
Reverts enterprise-contract/enterprise-contract.github.io#180

Deploy started failing see https://github.com/enterprise-contract/enterprise-contract.github.io/actions/runs/7263221624