### PR TITLE
Nicer /posts page styling

### DIFF
--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -922,3 +922,55 @@ ul.pagination
 .doc .source-toolbox .copy-toast {
   width: 4rem;
 }
+
+body.posts > .body > .article > .content {
+  padding: 1rem;
+
+  [id] {
+    scroll-margin-top: 6rem;
+  }
+
+  aside {
+    position: fixed;
+    width: 20rem;
+    background: top / 40% no-repeat url('/images/logo.svg');
+    padding-top: 9rem;
+
+    h1 {
+      font-weight: normal;
+      color: var(--navbar-font-color);
+    }
+
+    nav ol {
+      list-style: none;
+      padding-left: 0.5rem;
+
+      li {
+        margin-bottom: 0.5rem;
+      }
+    }
+  }
+
+  h1 {
+    a {
+      text-decoration: none;
+    }
+
+    font-size: 3rem;
+    border-bottom: 0;
+  }
+
+  article {
+    article:not(:first-child) {
+      margin-top: 6rem;
+    }
+
+    svg {
+      filter: drop-shadow(2px 2px 0 var(--ec-icon-purple));
+    }
+  }
+
+  article.doc {
+    margin-left: 23rem;
+  }
+}

--- a/website/config/_default/hugo.toml
+++ b/website/config/_default/hugo.toml
@@ -7,3 +7,7 @@ copyright = "Red Hat, Inc. All rights reserved."
 relativeURLs = true
 staticDir = ["static", "antora"]
 paginate = 2
+
+[services]
+  [services.rss]
+    limit = 10

--- a/website/content/posts/_index.md
+++ b/website/content/posts/_index.md
@@ -1,3 +1,7 @@
 ---
-title: "Blog"
+title: "Enterprise Contract Blog"
 ---
+
+Read up on news, announcements and tutorials.
+
+Want to contribute a post? Add a new file [here](https://github.com/enterprise-contract/enterprise-contract.github.io/new/main/website/content/posts).

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
   <head>
     {{ partial "head.html" . }}
   </head>
-  <body class="article">
+  <body class="article {{ .Type }}">
     {{ partial "header.html" . }}
     <div class="body">
       {{ partial "nav.html" . }}

--- a/website/layouts/posts/list.html
+++ b/website/layouts/posts/list.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+  <article>
+    <aside>
+      <h1>{{ .Title | markdownify }}</h1>
+      {{.Content }}
+      <p>
+        On this page:
+        <nav>
+          <ol>
+            {{ range .Paginator.Pages }}
+              <li><a href="#{{ .LinkTitle }}">{{ .LinkTitle }}</a></li>
+            {{ end }}
+          </ol>
+        </nav>
+      </p>
+      <p>
+        Other pages:
+        <div class="pagination-centered">
+          {{ template "_internal/pagination.html" (dict "page" . "format" "terse") }}
+        </div>
+      </p>
+    </aside>
+  </article>
+  <article class="doc">
+    {{ range .Paginator.Pages }}
+    <article>
+      <h1><a id="{{ .LinkTitle }}" href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h1>
+        {{ partial "post-meta.html" . }}
+      <div class="paragraph">
+        <p>{{ .Content }}</p>
+      </div>
+
+      {{ $icon := resources.Get "svg/heroicons/24/outline/code-bracket.svg" }}
+      {{ $icon.Content | safeHTML }}
+    </article>
+    {{ end }}
+  </article>
+{{ end }}


### PR DESCRIPTION
Shows full blog posts (up to 2, configurable in Hugo configuration). Adds the logo and a bit of text on the left.