### PR TITLE
Fix URL to AppStudio - Enterprise Contract docs

### DIFF
--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ organization specific policies as required.
 - *EC Policies* - A set of policies defined in OPA/Rego
 
 There's an additional overview of Enterprise Contract and its components in the
-https://redhat-appstudio.github.io/book/book/enterprise-contract.html[Book of
+https://redhat-appstudio.github.io/architecture/architecture/enterprise-contract.html[Book of
 AppStudio].
 
 == Code


### PR DESCRIPTION
I got a 404 when browsing the docs. I believe this is the correct URL, but might be wrong.