### PR TITLE
Development documentation and VSCode configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Antora Build",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run-script", "build:fast"
+            ],
+            "cwd": "${workspaceFolder}/antora"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,46 @@
 
 # enterprise-contract.github.io
 
-Content and build automation for [enterprisecontract.dev][ec].
+These are the sources for building the https://enterprisecontract.dev website.
+The website uses [Hugo](https://gohugo.io/) and
+[Antora](https://docs.antora.org/) to build different sections of the website.
 
 Includes:
 * [Website content](./website), built with [Hugo](https://gohugo.io/), published at [enterprisecontract.dev][ec]
-* [Documentation](./antora), built with [Antora](https://antora.org/), published at [enterprisecontract.dev/docs][ec-docs]
+* [Documentation](./antora), built with [Antora](https://antora.org/), published
+  at [enterprisecontract.dev/docs][ec-docs]
+
+
+## Live reload preview
+
+To run the preview of the website as changes are made to files within this
+repository run `make preview`. Note that the `preview` target also invokes
+`npm ci` in the `antora` directory which will reinstall and remove linked
+packages needed for development, running `npm run dev:setup` should restore the
+links and help with debugging. More on this below.
+
+## Development
+
+The website makes use of
+[Antora Extensions](https://docs.antora.org/antora/latest/extend/extensions/),
+there are several extensions defined as development dependencies in
+`antora/package.json` and configured in `antora/antora-playbook.yml`.
+
+To make changes locally to the extensions run `npm run dev:setup` script in the
+`antora` directory. The script assumes that the local clones of
+[ec-cli](https://github.com/enterprise-contract/ec-cli/) and
+[ec-policies](https://github.com/enterprise-contract/ec-policies/) repositories
+are present in the directory above this one. The outcome of running the
+`dev:setup` script is that local copies of the NPM packages that comprise the
+extensions are [linked](https://docs.npmjs.com/cli/v6/commands/npm-link), so
+instead of the versions released to npmjs.com, local versions with any local
+changes will be used.
+
+Opening the `enterprise-contract.github.io.code-workspace` workspace file within
+VSCode will load the Node projects of the same extensions and the `Antora Build`
+launch configuration in `.vscode/launch.json` allows running the debugger
+against those.
+
 
 [ec]: https://enterprisecontract.dev
 [ec-docs]: https://enterprisecontract.dev/docs

--- a/antora/package.json
+++ b/antora/package.json
@@ -22,7 +22,9 @@
   "scripts": {
     "build:base": "antora generate antora-playbook.yml",
     "build": "npm run build:base -- --clean --fetch",
-    "build:fast": "npm run build:base"
+    "build:fast": "npm run build:base",
+    "dev:links": "(cd ../../ec-policies/antora/ec-policies-antora-extension && npm ci && npm link) && (cd ../../ec-cli/reference-antora-extension && npm link) && (cd ../../ec-cli/rego-antora-extension && npm link) && (cd ../../ec-cli/tekton-task-antora-extension && npm link)",
+    "dev:setup": "npm run dev:links && npm link @enterprise-contract/ec-policies-antora-extension @enterprise-contract/reference-antora-extension @enterprise-contract/rego-antora-extension @enterprise-contract/tekton-task-antora-extension"
   },
   "engines": {
     "node": "18"

--- a/enterprise-contract.github.io.code-workspace
+++ b/enterprise-contract.github.io.code-workspace
@@ -1,0 +1,20 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../ec-cli/reference-antora-extension"
+		},
+		{
+			"path": "../ec-cli/rego-antora-extension"
+		},
+		{
+			"path": "../ec-cli/tekton-task-antora-extension"
+		},
+		{
+			"path": "../ec-policies/antora/ec-policies-antora-extension"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Documents how to run the website preview and how to run/debug the Antora build by using VSCode and `npm link`.

Reference: EC-496