### PR TITLE
Remove reference-antora-extension

### DIFF
--- a/antora/antora-playbook.yml
+++ b/antora/antora-playbook.yml
@@ -59,7 +59,6 @@ antora:
     - require: '@enterprise-contract/ec-policies-antora-extension'
     - require: '@enterprise-contract/tekton-task-antora-extension'
     - require: '@enterprise-contract/rego-antora-extension'
-    - require: '@enterprise-contract/reference-antora-extension'
     - require: '@release-engineering/ec-data-extension'
     - '@antora/lunr-extension'
     - require: './extensions/zoom.js'

--- a/antora/package-lock.json
+++ b/antora/package-lock.json
@@ -14,9 +14,8 @@
       },
       "devDependencies": {
         "@enterprise-contract/ec-policies-antora-extension": "latest",
-        "@enterprise-contract/reference-antora-extension": "*",
-        "@enterprise-contract/rego-antora-extension": "*",
-        "@enterprise-contract/tekton-task-antora-extension": "*",
+        "@enterprise-contract/rego-antora-extension": "latest",
+        "@enterprise-contract/tekton-task-antora-extension": "latest",
         "@release-engineering/ec-data-extension": "^1.0.1-test.0",
         "antora": "^3.1.7",
         "toml": "^3.0.0"
@@ -365,15 +364,6 @@
       },
       "engines": {
         "node": "18"
-      }
-    },
-    "node_modules/@enterprise-contract/reference-antora-extension": {
-      "version": "0.0.1-609d5c7e3885616603167638a219cbd28c319cc1.0",
-      "resolved": "https://registry.npmjs.org/@enterprise-contract/reference-antora-extension/-/reference-antora-extension-0.0.1-609d5c7e3885616603167638a219cbd28c319cc1.0.tgz",
-      "integrity": "sha512-iX0ClAFvy6070kRUuoID2YBcGAbry+FR4kT6dduHgNDg4CgBRvdp3d7Eur6Jan9gyNfM7rEsS4qsUWInkKNUnQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@enterprise-contract/rego-antora-extension": {

--- a/antora/package.json
+++ b/antora/package.json
@@ -9,7 +9,6 @@
   "homepage": "https://enterprise-contract.github.io/enterprise-contract.github.io/",
   "devDependencies": {
     "@enterprise-contract/ec-policies-antora-extension": "latest",
-    "@enterprise-contract/reference-antora-extension": "latest",
     "@enterprise-contract/rego-antora-extension": "latest",
     "@enterprise-contract/tekton-task-antora-extension": "latest",
     "@release-engineering/ec-data-extension": "^1.0.1-test.0",


### PR DESCRIPTION
`@enterprise-contract/reference-antora-extension` is no longer used, this removes it.

Reference: EC-513