### PR TITLE
Fix invalid timestamp in newest blog post

### DIFF
--- a/website/content/posts/gating-image-promotion-on-gitlab.md
+++ b/website/content/posts/gating-image-promotion-on-gitlab.md
@@ -1,6 +1,6 @@
 ---
 title: "Gating Image Promotion on GitLab"
-date: 2024-06-12T18:64:00-00:00
+date: 2024-06-12T18:54:00-00:00
 author: "Luiz Carvalho"
 ---
 


### PR DESCRIPTION
Hugo was unable to parse the timestamp so it was giving it a nil date and hence showing up way down the bottom on the blog page.