### PR TITLE
Avoid ping-pong local rebuild triggering

### DIFF
--- a/antora/hack/local-live.sh
+++ b/antora/hack/local-live.sh
@@ -13,6 +13,7 @@ ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
     trap exit SIGINT
     # shellcheck disable=SC2016,SC2046
     while true; do
-        find $(yq '.content.sources[].url | sub(".*/(.*)\.git", "../../$1")' "${ROOT_DIR}/antora-playbook.yml") | entr -s 'echo Building ...; '"${ROOT_DIR}"/hack/local-build.sh'; echo Waiting for changes, press Ctrl+C to exit' || true
+        watch_dirs=$(yq '.content.sources[].url | sub(".*/(.*)\.git", "../../$1") | sub("../$", "../antora")' "${ROOT_DIR}/antora-playbook.yml")
+        find $watch_dirs | entr -s 'echo Building ...; '"${ROOT_DIR}"/hack/local-build.sh'; echo Waiting for changes, press Ctrl+C to exit' || true
     done
 )


### PR DESCRIPTION
I'm running `make hugo-server` in one terminal and `make antora-local-live` in another, and I'm seeing antora rebuilds trigger a hugo refresh which then triggers another antora rebuild and so-on forever.

Fix it by narrowing the list of directories being watched by entr in the antora local list script. Watch just "./antora" dir in this repo, instead of "./" so files touched by hugo don't trigger an antora rebuild.

(This is a quick hack - I expect there's a nicer way to do this.)

Ref: https://issues.redhat.com/browse/EC-155