### PR TITLE
Include all doc components in left panel nav

### DIFF
--- a/antora/docs/modules/ROOT/nav.adoc
+++ b/antora/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,1 @@
 * xref:index.adoc[Overview]
-* xref:ec-cli:ROOT:ec_validate_image.adoc[CLI Reference]
-* xref:ec-cli:ROOT:verify-enterprise-contract.adoc[Tekton Tasks]
-* xref:ecc:ROOT:index.adoc[Configuration]
-* xref:ec-policies:ROOT:release_policy.adoc[Policies]
-* xref:user-guide:ROOT:index.adoc[User Guide]

--- a/antora/supplemental-ui/partials/nav-menu.hbs
+++ b/antora/supplemental-ui/partials/nav-menu.hbs
@@ -1,0 +1,20 @@
+{{!--
+  Include the navigation from every component instead of just the current one.
+  Default version is here:
+  https://gitlab.com/antora/antora-ui-default/-/blob/master/src/partials/nav-menu.hbs
+--}}
+<div class="nav-panel-menu is-active" data-panel="menu">
+  <nav class="nav-menu">
+    <ul class="nav-list">
+      {{#each site.components}}
+        {{#with ./latest}}
+          <li class="nav-item component-title">
+            <button class="nav-item-toggle"></button>
+            <a class="nav-link" href="{{{relativize ./url}}}">{{./title}}</a>
+            {{> nav-tree navigation=./navigation}}
+          </li>
+        {{/with}}
+      {{/each}}
+    </ul>
+  </nav>
+</div>

--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -934,3 +934,35 @@ ul.pagination
   border-radius: 3px;
   border-color: var(--footer-background);
 }
+
+/* Antora nav menu stuff */
+.nav-panel-menu .nav-item {
+  /* All top level titles */
+  &.component-title {
+    margin-bottom: 0.4rem;
+
+    >.nav-link {
+      font-size: 105%;
+    }
+  }
+
+  /* Expanded top level titles */
+  &.component-title.is-active {
+    margin-bottom: 0.8rem;
+  }
+
+  /* Higlighted top level titles */
+  &.component-title.is-current-path {
+    >.nav-link {
+      color: var(--ec-icon-purple);
+      font-weight: bold;
+    }
+  }
+
+  /* The current page */
+  &.is-current-page {
+    >.nav-link {
+      color: var(--ec-icon-purple);
+    }
+  }
+}

--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -963,6 +963,12 @@ ul.pagination
   &.is-current-page {
     >.nav-link {
       color: var(--ec-icon-purple);
+
+      &:after {
+        /* \00a0 is an &nbsp; char */
+        content: '\00a0→';
+        font-weight: bold;
+      }
     }
   }
 }


### PR DESCRIPTION
The default antora UI theme includes nav links from just the current component. Change it so we include nav links from all the components.

This improves the coherence of the docs and helps to reveal the shortcomings of the current structure, which I want to try to improve in some future PRs.

Also remove some links from the nav.adoc in this repo, since a. they're no longer useful now that the same links are in the nav menu, and b. because they are duplicates of the main component link, they actually break the javascript interactive menu tree handling.

Also includes some custom CSS to tweak the size, spacing, and add some color to highlighted nav links.

Ref: https://issues.redhat.com/browse/EC-155