### PR TITLE
Prepare for unversioned antora components

### DIFF
--- a/antora/antora-playbook.yml
+++ b/antora/antora-playbook.yml
@@ -27,16 +27,16 @@ site:
 content:
   sources:
     - url: https://github.com/enterprise-contract/ec-policies.git
-      branches: main
       start_path: antora/docs
+
     - url: https://github.com/enterprise-contract/ec-cli.git
-      branches: main
       start_path: docs
+
     - url: https://github.com/enterprise-contract/enterprise-contract-controller.git
-      branches: main
       start_path: docs
+
     - url: https://github.com/enterprise-contract/user-guide.git
-      branches: main
+
 ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable

--- a/website/config/_default/menu.toml
+++ b/website/config/_default/menu.toml
@@ -20,25 +20,25 @@
   [[main]]
     name = 'User Guide'
     parent = 'Documentation'
-    url = '/docs/user-guide/main'
+    url = '/docs/user-guide/'
     weight = 10
 
   [[main]]
     name = 'CLI Reference'
     parent = 'Documentation'
-    url = '/docs/ec-cli/main/ec_validate_image.html'
+    url = '/docs/ec-cli/ec_validate_image.html'
     weight = 20
 
   [[main]]
     name = 'Tekton Tasks'
     parent = 'Documentation'
-    url = '/docs/ec-cli/main/verify-enterprise-contract.html'
+    url = '/docs/ec-cli/verify-enterprise-contract.html'
     weight = 30
 
   [[main]]
     name = 'Configuration'
     parent = 'Documentation'
-    url = '/docs/ecc/main'
+    url = '/docs/ecc/'
     weight = 40
 
   [[main]]

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,4 +4,4 @@ kind: home
 
 ### [{{< icon "arrow-down-circle" >}} Download](https://github.com/enterprise-contract/ec-cli/releases/tag/snapshot){#download .button}
 
-### [{{< icon "book-open" >}} Getting Started](./docs/user-guide/main/hitchhikers-guide.html){.button}
+### [{{< icon "book-open" >}} Getting Started](docs/user-guide/hitchhikers-guide.html){.button}

--- a/website/content/posts/evaluating-custom-predicates.md
+++ b/website/content/posts/evaluating-custom-predicates.md
@@ -7,7 +7,7 @@ author: "Luiz Carvalho"
 Attestations are a wonderful way to attach metadata to container images in a secure manner. One of
 the most popular formats is [SLSA Provenance](https://slsa.dev/spec/v0.1/provenance#schema) which is
 used to provide information on how the image was created. Our [Hitchhiker’s
-Guide](https://enterprisecontract.dev/docs/user-guide/main/hitchhikers-guide.html) demonstrates how
+Guide](https://enterprisecontract.dev/docs/user-guide/hitchhikers-guide.html) demonstrates how
 to write policies to assert the contents of the SLSA Provenance. Here, we expand on that approach to
 assert the contents of *any* attestation format, even completely made up ones.
 
@@ -15,7 +15,7 @@ assert the contents of *any* attestation format, even completely made up ones.
 
 Before getting started, let's make sure we have an image that is already signed and has a SLSA
 Provenance attestation. We will also need access to the signing key used. The [Hitchhiker’s
-Guide](https://enterprisecontract.dev/docs/user-guide/main/hitchhikers-guide.html) walks through the
+Guide](https://enterprisecontract.dev/docs/user-guide/hitchhikers-guide.html) walks through the
 process. If you want to try out the commands in this blog post, start there.
 
 When we talk about different attestation formats, what we are really saying is different **predicate

--- a/website/content/posts/introducing-action-validate-image.md
+++ b/website/content/posts/introducing-action-validate-image.md
@@ -20,7 +20,7 @@ processes or any other automated workflow in GitHub.
 - **GitHub Native**: Being a GitHub Action, EC Validate seamlessly integrates into your existing GitHub workflows, while also providing GitHub summary output.
 - **Policy Compliance**: Ability to tailor its validation checks based on custom or pre-defined policies.
 - **Integrity Checks**: Verifies that the image hasn't been tampered with.
-- **[Signature Verification Support](https://enterprisecontract.dev/docs/ec-cli/main/signing.html)**: Offers support for verifying both long-lived public-key signed, and keyless signed container images.
+- **[Signature Verification Support](https://enterprisecontract.dev/docs/ec-cli/signing.html)**: Offers support for verifying both long-lived public-key signed, and keyless signed container images.
 
 Interested in learning more? Visit the EC Validate action in [GitHub's Market Place](https://github.com/marketplace/actions/ec-validate) for a user guide.
 
@@ -111,7 +111,7 @@ Here is a version of the EC Action Validate that verifies artifacts signed by co
 - **`image`**: Similar to keyless, specifies the container image to be validated.
 - **`key`**: The public key used for long-lived authentication.
 - **`policy`**: Policy configuration, which can be either [predefined](https://github.com/enterprise-contract/config) or custom.
-- **`extra-params`**: Additional parameters for the action, such as ignoring Rekor for this image. More can be found [here](https://enterprisecontract.dev/docs/ec-cli/main/ec_validate_image.html#_options)
+- **`extra-params`**: Additional parameters for the action, such as ignoring Rekor for this image. More can be found [here](https://enterprisecontract.dev/docs/ec-cli/ec_validate_image.html#_options)
 
 By using either keyless or long-lived authentication methods, you can tailor EC Action Validate to meet the specific security requirements of your project.
 

--- a/website/content/posts/introducing-the-enterprise-contract.md
+++ b/website/content/posts/introducing-the-enterprise-contract.md
@@ -5,7 +5,7 @@ date: 2023-04-24T12:56:35-04:00
 
 You may have heard of [sigstore](https://www.sigstore.dev/how-it-works) and its container image
 verification tool, [cosign](https://docs.sigstore.dev/cosign/overview/). This blog post introduces a
-policy-driven workflow, [Enterprise Contract](https://enterprisecontract.dev/docs/ec/main/index.html),
+policy-driven workflow, [Enterprise Contract](https://enterprisecontract.dev/docs/),
 built on those technologies.
 
 <!--more-->
@@ -164,7 +164,7 @@ rekorUrl: ""
 ```
 
 The sources attribute specifies a list of rego policy rules and corresponding [data
-sources](https://enterprisecontract.dev/docs/ec-cli/main/configuration.html#_data_sources). Each data and
+sources](https://enterprisecontract.dev/docs/ec-cli/configuration.html#_data_sources). Each data and
 policy source can be specified via a different set of transports. Here we choose to use them
 directly from git.
 
@@ -172,7 +172,7 @@ In configuration, we specify what to include from the sources. (Omit this to inc
 example, the policy rules from the
 [slsa_source_version_controlled](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa_source_version_controlled_package)
 package are included. Check out the
-[docs](https://enterprisecontract.dev/docs/ec-cli/main/configuration.html) for more information.
+[docs](https://enterprisecontract.dev/docs/ec-cli/configuration.html) for more information.
 
 We can also specify the public key and rekor URL directly in this file. This helps consolidate all
 the input parameters required for validating images.
@@ -298,5 +298,5 @@ plan on improving it even more. An important feature currently being worked on i
 keyless workflows which will increase the number of supported use cases.
 
 If you want to learn more, check out our
-[docs](https://enterprisecontract.dev/docs/ec/main/index.html) and browse [the
+[docs](https://enterprisecontract.dev/docs/) and browse [the
 source](https://github.com/enterprise-contract)!


### PR DESCRIPTION
Update links to remove the "/main/" version path segment.

Ref: https://issues.redhat.com/browse/EC-86