### PR TITLE
Update urls to new domain name

### DIFF
--- a/antora/antora-playbook.yml
+++ b/antora/antora-playbook.yml
@@ -21,8 +21,7 @@ runtime:
     failure_level: warn
 site:
   title: Conforma
-  url: https://enterprisecontract.dev/docs
-  #url: https://conforma.dev/docs
+  url: https://conforma.dev/docs
   start_page: user-guide::index.adoc
   robots: allow
 content:

--- a/website/content/posts/a-taste-of-policies.md
+++ b/website/content/posts/a-taste-of-policies.md
@@ -5,7 +5,7 @@ author: "Luiz Carvalho"
 ---
 
 In a [previous blog
-post](https://enterprisecontract.dev/posts/introducing-the-enterprise-contract/), we introduced the
+post](https://conforma.dev/posts/introducing-the-enterprise-contract/), we introduced the
 basic concepts of the Enterprise Contract. This time, we explore it further to showcase the usage of
 policies.
 
@@ -86,7 +86,7 @@ configuration:
 
 This policy moves the certificate flags to the policy itself. It also specifies certain policy rules
 to be executed. Here we are including some of the existing Enterprise Contract policy rules,
-[github_certificate](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#github_certificate_package).
+[github_certificate](https://conforma.dev/docs/ec-policies/release_policy.html#github_certificate_package).
 These policy rules rely on certain data to be provided, e.g. the expected GitHub Workflow
 repository. With this policy saved as `policy.yaml`, we can simplify how the CLI is invoked:
 
@@ -189,7 +189,7 @@ deny contains result if {
 This defines a single policy rule that verifies the materials section of the SLSA Provenance contain
 the expected git repository. The Enterprise Contract relies on rego annotations to provide
 additional information about each of the policy rules. See the
-[docs](https://enterprisecontract.dev/docs/ec-policies/authoring.html) for more information.
+[docs](https://conforma.dev/docs/ec-policies/authoring.html) for more information.
 
 Let's add this rule to our previous policy:
 

--- a/website/content/posts/evaluating-custom-predicates.md
+++ b/website/content/posts/evaluating-custom-predicates.md
@@ -7,7 +7,7 @@ author: "Luiz Carvalho"
 Attestations are a wonderful way to attach metadata to container images in a secure manner. One of
 the most popular formats is [SLSA Provenance](https://slsa.dev/spec/v0.1/provenance#schema) which is
 used to provide information on how the image was created. Our [Hitchhiker’s
-Guide](https://enterprisecontract.dev/docs/user-guide/hitchhikers-guide.html) demonstrates how
+Guide](https://conforma.dev/docs/user-guide/hitchhikers-guide.html) demonstrates how
 to write policies to assert the contents of the SLSA Provenance. Here, we expand on that approach to
 assert the contents of *any* attestation format, even completely made up ones.
 
@@ -17,7 +17,7 @@ assert the contents of *any* attestation format, even completely made up ones.
 
 Before getting started, let's make sure we have an image that is already signed and has a SLSA
 Provenance attestation. We will also need access to the signing key used. The [Hitchhiker’s
-Guide](https://enterprisecontract.dev/docs/user-guide/hitchhikers-guide.html) walks through the
+Guide](https://conforma.dev/docs/user-guide/hitchhikers-guide.html) walks through the
 process. If you want to try out the commands in this blog post, start there.
 
 When we talk about different attestation formats, what we are really saying is different **predicate
@@ -111,7 +111,7 @@ _bacon_attestations := [attestation |
 ]
 ```
 
-(Check out the [docs](https://enterprisecontract.dev/docs/ec-policies/authoring.html) for more
+(Check out the [docs](https://conforma.dev/docs/ec-policies/authoring.html) for more
 information on how to author policy rules 🔥)
 
 Next, we create a policy configuration, `policy.yaml`, to use the policy rules above.

--- a/website/content/posts/gating-image-promotion-on-gitlab.md
+++ b/website/content/posts/gating-image-promotion-on-gitlab.md
@@ -296,7 +296,7 @@ GitLab.
 [GitLab container registry]: https://docs.gitlab.com/ee/user/packages/container_registry/
 [identity-based]: https://docs.sigstore.dev/signing/overview/
 [SLSA Provenance]: https://slsa.dev/spec/v1.0/
-[slsa_source_correlated]: https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa_source_correlated_package
+[slsa_source_correlated]: https://conforma.dev/docs/ec-policies/release_policy.html#slsa_source_correlated_package
 
 ## Appendix
 

--- a/website/content/posts/introducing-action-validate-image.md
+++ b/website/content/posts/introducing-action-validate-image.md
@@ -22,7 +22,7 @@ processes or any other automated workflow in GitHub.
 - **GitHub Native**: Being a GitHub Action, EC Validate seamlessly integrates into your existing GitHub workflows, while also providing GitHub summary output.
 - **Policy Compliance**: Ability to tailor its validation checks based on custom or pre-defined policies.
 - **Integrity Checks**: Verifies that the image hasn't been tampered with.
-- **[Signature Verification Support](https://enterprisecontract.dev/docs/ec-cli/signing.html)**: Offers support for verifying both long-lived public-key signed, and keyless signed container images.
+- **[Signature Verification Support](https://conforma.dev/docs/ec-cli/signing.html)**: Offers support for verifying both long-lived public-key signed, and keyless signed container images.
 
 Interested in learning more? Visit the EC Validate action in [GitHub's Market Place](https://github.com/marketplace/actions/ec-validate) for a user guide.
 
@@ -113,7 +113,7 @@ Here is a version of the EC Action Validate that verifies artifacts signed by co
 - **`image`**: Similar to keyless, specifies the container image to be validated.
 - **`key`**: The public key used for long-lived authentication.
 - **`policy`**: Policy configuration, which can be either [predefined](https://github.com/enterprise-contract/config) or custom.
-- **`extra-params`**: Additional parameters for the action, such as ignoring Rekor for this image. More can be found [here](https://enterprisecontract.dev/docs/ec-cli/ec_validate_image.html#_options)
+- **`extra-params`**: Additional parameters for the action, such as ignoring Rekor for this image. More can be found [here](https://conforma.dev/docs/ec-cli/ec_validate_image.html#_options)
 
 By using either keyless or long-lived authentication methods, you can tailor EC Action Validate to meet the specific security requirements of your project.
 

--- a/website/content/posts/introducing-the-enterprise-contract.md
+++ b/website/content/posts/introducing-the-enterprise-contract.md
@@ -5,7 +5,7 @@ date: 2023-04-24T12:56:35-04:00
 
 You may have heard of [sigstore](https://www.sigstore.dev/how-it-works) and its container image
 verification tool, [cosign](https://docs.sigstore.dev/cosign/overview/). This blog post introduces a
-policy-driven workflow, [Enterprise Contract](https://enterprisecontract.dev/docs/),
+policy-driven workflow, [Enterprise Contract](https://conforma.dev/docs/),
 built on those technologies.
 
 <!--more-->
@@ -166,15 +166,15 @@ rekorUrl: ""
 ```
 
 The sources attribute specifies a list of rego policy rules and corresponding [data
-sources](https://enterprisecontract.dev/docs/ec-cli/configuration.html#_data_sources). Each data and
+sources](https://conforma.dev/docs/ec-cli/configuration.html#_data_sources). Each data and
 policy source can be specified via a different set of transports. Here we choose to use them
 directly from git.
 
 In configuration, we specify what to include from the sources. (Omit this to include all!) In this
 example, the policy rules from the
-[slsa_source_version_controlled](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#slsa_source_version_controlled_package)
+[slsa_source_version_controlled](https://conforma.dev/docs/ec-policies/release_policy.html#slsa_source_version_controlled_package)
 package are included. Check out the
-[docs](https://enterprisecontract.dev/docs/ec-cli/configuration.html) for more information.
+[docs](https://conforma.dev/docs/ec-cli/configuration.html) for more information.
 
 We can also specify the public key and rekor URL directly in this file. This helps consolidate all
 the input parameters required for validating images.
@@ -300,5 +300,5 @@ plan on improving it even more. An important feature currently being worked on i
 keyless workflows which will increase the number of supported use cases.
 
 If you want to learn more, check out our
-[docs](https://enterprisecontract.dev/docs/) and browse [the
+[docs](https://conforma.dev/docs/) and browse [the
 source](https://github.com/enterprise-contract)!


### PR DESCRIPTION
Now that it's been cut over, we should fix some urls, particularly the main home url in the antora playbook.

Ref: https://issues.redhat.com/browse/EC-1081