### PR TITLE
chore(playbook): update source URL for user-guide.

### DIFF
--- a/antora/antora-playbook.yml
+++ b/antora/antora-playbook.yml
@@ -35,7 +35,7 @@ content:
     - url: https://github.com/enterprise-contract/enterprise-contract-controller.git
       start_path: docs
 
-    - url: https://github.com/enterprise-contract/user-guide.git
+    - url: https://github.com/conforma/user-guide.git
 
 ui:
   bundle:


### PR DESCRIPTION
This commit updates the source URL for the user-guide component which changed from `github.com/enterprise-contract/user-guide` to `github.com/conforma/user-guide`.

Ref: EC-1114