### PR TITLE
Update doc links to new package pages

### DIFF
--- a/website/content/posts/a-taste-of-policies.md
+++ b/website/content/posts/a-taste-of-policies.md
@@ -86,7 +86,7 @@ configuration:
 
 This policy moves the certificate flags to the policy itself. It also specifies certain policy rules
 to be executed. Here we are including some of the existing Enterprise Contract policy rules,
-[github_certificate](https://conforma.dev/docs/policy/release_policy.html#github_certificate_package).
+[github_certificate](https://conforma.dev/docs/policy/packages/release_github_certificate.html).
 These policy rules rely on certain data to be provided, e.g. the expected GitHub Workflow
 repository. With this policy saved as `policy.yaml`, we can simplify how the CLI is invoked:
 

--- a/website/content/posts/gating-image-promotion-on-gitlab.md
+++ b/website/content/posts/gating-image-promotion-on-gitlab.md
@@ -296,7 +296,7 @@ GitLab.
 [GitLab container registry]: https://docs.gitlab.com/ee/user/packages/container_registry/
 [identity-based]: https://docs.sigstore.dev/signing/overview/
 [SLSA Provenance]: https://slsa.dev/spec/v1.0/
-[slsa_source_correlated]: https://conforma.dev/docs/policy/release_policy.html#slsa_source_correlated_package
+[slsa_source_correlated]: https://conforma.dev/docs/policy/packages/release_slsa_source_correlated.html
 
 ## Appendix
 

--- a/website/content/posts/introducing-the-enterprise-contract.md
+++ b/website/content/posts/introducing-the-enterprise-contract.md
@@ -172,7 +172,7 @@ directly from git.
 
 In configuration, we specify what to include from the sources. (Omit this to include all!) In this
 example, the policy rules from the
-[slsa_source_version_controlled](https://conforma.dev/docs/policy/release_policy.html#slsa_source_version_controlled_package)
+[slsa_source_version_controlled](https://conforma.dev/docs/policy/packages/release_slsa_source_version_controlled.html)
 package are included. Check out the
 [docs](https://conforma.dev/docs/ec-cli/configuration.html) for more information.
 


### PR DESCRIPTION
Following a split up of policy pages in Conforma docs, there is a dedicated page for each policy package.

Ref: https://issues.redhat.com/browse/EC-1322